### PR TITLE
Replaced Google Analytics tag with Google Tag Manager

### DIFF
--- a/LeadIQ/ClientApp/public/index.html
+++ b/LeadIQ/ClientApp/public/index.html
@@ -43,14 +43,13 @@
     </script>
     <!-- End of Async Drift Code -->
     
-    <!-- Global Site Tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-55278362-5"></script> 
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'UA-55278362-5');       
-    </script>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-W6LCLM2');</script>
+    <!-- End Google Tag Manager -->
     
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"  integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
@@ -59,6 +58,10 @@
     <script type="text/javascript" id="vidyard_embed_code_DL4Se2hW1v5CRHiEfpDnoc" src="//play.vidyard.com/DL4Se2hW1v5CRHiEfpDnoc.js?v=3.1.1&type=lightbox"></script>
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W6LCLM2"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <noscript>
         You need to enable JavaScript to run this app.
     </noscript>


### PR DESCRIPTION
This is the Google Tag Manager script that was previously running on the site. It includes Act-On, Hotjar, Facebook and Google Event Tracking.